### PR TITLE
fix bug for rtmp_player.go

### DIFF
--- a/demo/player/rtmp_player.go
+++ b/demo/player/rtmp_player.go
@@ -38,7 +38,7 @@ var status uint
 
 func (handler *TestOutboundConnHandler) OnStatus(conn rtmp.OutboundConn) {
 	var err error
-	status, err = obConn.Status()
+	status, err = conn.Status()
 	fmt.Printf("@@@@@@@@@@@@@status: %d, err: %v\n", status, err)
 }
 
@@ -77,6 +77,7 @@ func main() {
 	}
 	flag.Parse()
 
+	fmt.Printf("rtmp:%s stream:%s flv:%s\r\n", *url,*streamName,*dumpFlv)
 	l := log.NewLogger(".", "player", nil, 60, 3600*24, true)
 	rtmp.InitLogger(l)
 	defer l.Close()


### PR DESCRIPTION
使用go 1.6编译，运行rtmpplayer的时候报错。

to dial
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x50 pc=0x207d]

goroutine 1 [running]:
panic(0x278060, 0xc8200120e0)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
main.(*TestOutboundConnHandler).OnStatus(0x432060, 0x1145890, 0xc82008e280)
	/Users/daozhao/Documents/sourcecode/goPath/src/github.com/zhangpeihao/gortmp/demo/player/rtmp_player.go:41 +0x3d
github.com/zhangpeihao/gortmp.Dial(0x7fff5fbffa9a, 0x15, 0x1144628, 0x432060, 0x64, 0x0, 0x0, 0x0, 0x0)
	/Users/daozhao/Documents/sourcecode/goPath/src/github.com/zhangpeihao/gortmp/outboundconn.go:109 +0x878
main.main()
	/Users/daozhao/Documents/sourcecode/goPath/src/github.com/zhangpeihao/gortmp/demo/player/rtmp_player.go:104 +0x4e0