### PR TITLE
fixbuf, rtmpplayer, write flv file, timestamp error

### DIFF
--- a/demo/player/rtmp_player.go
+++ b/demo/player/rtmp_player.go
@@ -6,13 +6,14 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/zhangpeihao/goflv"
-	rtmp "github.com/zhangpeihao/gortmp"
-	"github.com/zhangpeihao/log"
 	"io"
 	"net"
 	"os"
 	"time"
+
+	"github.com/zhangpeihao/goflv"
+	rtmp "github.com/zhangpeihao/gortmp"
+	"github.com/zhangpeihao/log"
 )
 
 const (
@@ -50,12 +51,12 @@ func (handler *TestOutboundConnHandler) OnReceived(conn rtmp.Conn, message *rtmp
 	switch message.Type {
 	case rtmp.VIDEO_TYPE:
 		if flvFile != nil {
-			flvFile.WriteVideoTag(message.Buf.Bytes(), message.Timestamp)
+			flvFile.WriteVideoTag(message.Buf.Bytes(), message.AbsoluteTimestamp)
 		}
 		videoDataSize += int64(message.Buf.Len())
 	case rtmp.AUDIO_TYPE:
 		if flvFile != nil {
-			flvFile.WriteAudioTag(message.Buf.Bytes(), message.Timestamp)
+			flvFile.WriteAudioTag(message.Buf.Bytes(), message.AbsoluteTimestamp)
 		}
 		audioDataSize += int64(message.Buf.Len())
 	}
@@ -77,7 +78,7 @@ func main() {
 	}
 	flag.Parse()
 
-	fmt.Printf("rtmp:%s stream:%s flv:%s\r\n", *url,*streamName,*dumpFlv)
+	fmt.Printf("rtmp:%s stream:%s flv:%s\r\n", *url, *streamName, *dumpFlv)
 	l := log.NewLogger(".", "player", nil, 60, 3600*24, true)
 	rtmp.InitLogger(l)
 	defer l.Close()


### PR DESCRIPTION
解决Issues #17中提到的flv文件不能播放的问题。   
